### PR TITLE
Remove use of depricated sudo module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,30 +6,26 @@
   when: not (ansible_os_family == 'Debian' or ansible_distribution == 'Ubuntu')
 
 - name: Debian | install automysqlbackup
-  sudo: yes
   apt: pkg=automysqlbackup state=latest update_cache=yes
   tags:
     - automysqlbackup
 
 - name: apply automysqlbackup configuration
-  sudo: yes
   template:
     src: automysqlbackup.j2
     dest: /etc/default/automysqlbackup
     group: root
     owner: root
-    mode: 0600
+    mode: "0600"
   tags:
     - automysqlbackup
 
 - name: remove the cron.daily file
-  sudo: yes
   file: path=/etc/cron.daily/automysqlbackup state=absent
   tags:
     - automysqlbackup
 
 - name: add automysqlbackup cron job
-  sudo: yes
   cron:
     name: "automysqlbackup"
     minute: "{{ automysqlbackup_cron.minute }}"


### PR DESCRIPTION
Update scripts for ansible 2.x as outlined here:
http://docs.ansible.com/ansible/become.html

become: yes
become_method: sudo